### PR TITLE
Clean up

### DIFF
--- a/app/assets/javascripts/browser_test.js.erb
+++ b/app/assets/javascripts/browser_test.js.erb
@@ -150,18 +150,16 @@ function testAll(){
     }
   });
 
-  //Load data from control site https://control.continuity.net/favicon.ico
-  $('#imagefavicon').on("error", function() {
-    $("#continuity_site").text("Not Loaded");
-    styleAsFailed("#continuity_site");
-    $("#user_datum_continuity_site").val("Not Loaded");
+  test('#continuity_site', function(pass, fail) {
+    //Load data from control site https://control.continuity.net/favicon.ico
+    $('#imagefavicon').on("error", function() {
+      fail('Not Loaded');
+    });
+    $('#imagefavicon').on("load", function(){
+      pass('Loaded');
+    });
+    $('#imagefavicon').attr('src', "https://control.continuity.net/browser-test.png");
   });
-  $('#imagefavicon').on("load", function(){
-    $("#continuity_site").text("Loaded");
-    styleAsPassed("#continuity_site");
-    $("#user_datum_continuity_site").val("Loaded");
-  });
-  $('#imagefavicon').attr('src', "https://control.continuity.net/browser-test.png");
 
   //loading data from 3rd party sites
   //beacon-3.newrelic.com - JavaScript performance monitoring

--- a/app/assets/javascripts/browser_test.js.erb
+++ b/app/assets/javascripts/browser_test.js.erb
@@ -5,21 +5,6 @@
    more object oriented?
  */
 
-function googleAnalytics(){
-  if (typeof _gat ===  'undefined') {
-    appendToOtherSites(false, "Google Analytics: Not Loaded");
-  }else{
-    appendToOtherSites(true, "Google Analytics: Loaded");
-  }
-}
-function googlejsapi(){
-  if (typeof google.loader === 'undefined') {
-    appendToOtherSites(false, "jsapi: Not Loaded");
-  }else{
-    appendToOtherSites(true, "jsapi: Loaded");
-  }
-}
-
 function styleAsPassed(domID) {
   $(domID).parents(".alert").removeClass("grey").removeClass('alert-error').addClass("alert-success");
 }
@@ -170,10 +155,18 @@ function testAll(){
   }
 
   //google.com/jsapi - Google for CDN of JS libraries
-  googlejsapi();
+  if (typeof google.loader === 'undefined') {
+    appendToOtherSites(false, "jsapi: Not Loaded");
+  }else{
+    appendToOtherSites(true, "jsapi: Loaded");
+  }
 
   //ssl.google-analytics.com - Site-usage analytics
-  googleAnalytics();
+  if (typeof _gat ===  'undefined') {
+    appendToOtherSites(false, "Google Analytics: Not Loaded");
+  }else{
+    appendToOtherSites(true, "Google Analytics: Loaded");
+  }
 
   //assets-cdn.continuity.net - Continuity Control's Content CDN
   if(typeof control.datepicker_opts === 'undefined'){

--- a/app/assets/javascripts/browser_test.js.erb
+++ b/app/assets/javascripts/browser_test.js.erb
@@ -134,15 +134,14 @@ function testAll(){
     }
   });
 
-  if(window.session.plugins.flash == true && window.session.plugins.flash != undefined){
-    $("#flash_enabled").text(window.session.plugins.flash);
-    styleAsPassed("#flash_enabled");
-    $("#user_datum_flash_enabled").val(window.session.plugins.flash);
-  }else{
-    $("#flash_enabled").text("False");
-    styleAsFailed("#flash_enabled");
-    $("#user_datum_flash_enabled").val("False");
-  }
+  test('#flash_enabled', function(pass, fail) {
+    if (window.session.plugins.flash == true && window.session.plugins.flash != undefined) {
+      pass(window.session.plugins.flash);
+    } else {
+      fail("False");
+    }
+  });
+
   if(Date() == undefined){
     $("#date").text("Undefined");
     styleAsFailed("#date");

--- a/app/assets/javascripts/browser_test.js.erb
+++ b/app/assets/javascripts/browser_test.js.erb
@@ -142,15 +142,13 @@ function testAll(){
     }
   });
 
-  if(Date() == undefined){
-    $("#date").text("Undefined");
-    styleAsFailed("#date");
-    $("#user_datum_date").val("Undefined");
-  }else{
-    $("#date").text(Date());
-    styleAsPassed("#date");
-    $("#user_datum_date").val(Date());
-  }
+  test('#date', function(pass, fail) {
+    if (Date() == undefined) {
+      fail('Undefined');
+    } else {
+      pass(Date());
+    }
+  });
 
   //Load data from control site https://control.continuity.net/favicon.ico
   $('#imagefavicon').on("error", function() {

--- a/app/assets/javascripts/browser_test.js.erb
+++ b/app/assets/javascripts/browser_test.js.erb
@@ -68,67 +68,67 @@ function testAll(){
 
   //loading data from client
   if(navigator.userAgent == undefined){
-    styleAsFailed("#userAgent");
-    $("#userAgent").text("Undefined");
+    styleAsFailed("#user_agent_string");
+    $("#user_agent_string").text("Undefined");
     $("#user_datum_user_agent_string").val("Undefined");
   }else if(blacklisted()){
-    styleAsFailed("#userAgent");
-    $("#userAgent").text(navigator.userAgent);
-    $("#userAgent").append("\n Your browser may be in a compatibility mode supporting an older version of IE.");
+    styleAsFailed("#user_agent_string");
+    $("#user_agent_string").text(navigator.userAgent);
+    $("#user_agent_string").append("\n Your browser may be in a compatibility mode supporting an older version of IE.");
     $("#user_datum_user_agent_string").val(navigator.userAgent);
   }else{
-    $("#userAgent").text(navigator.userAgent);
-    styleAsPassed("#userAgent");
+    $("#user_agent_string").text(navigator.userAgent);
+    styleAsPassed("#user_agent_string");
     $("#user_datum_user_agent_string").val(navigator.userAgent);
   }
 
   if(window.session.device.viewport.width == undefined && window.session.device.viewport.height == undefined){
-    $("#windowSize").text("Undefined");
-    styleAsFailed("#windowSize");
+    $("#window_size").text("Undefined");
+    styleAsFailed("#window_size");
     $("#user_datum_window_size").val("Undefined");
   }else{
-    $("#windowSize").text( window.session.device.viewport.width + " x "+ window.session.device.viewport.height);
-    styleAsPassed("#windowSize");
+    $("#window_size").text( window.session.device.viewport.width + " x "+ window.session.device.viewport.height);
+    styleAsPassed("#window_size");
     $("#user_datum_window_size").val(window.session.device.viewport.width + " x "+ window.session.device.viewport.height);
   }
 
   if(window.session.device.screen.width == undefined && window.session.device.screen.height == undefined){
-    $("#screenSize").text("Undefined");
-    styleAsFailed("#screenSize");
+    $("#screen_size").text("Undefined");
+    styleAsFailed("#screen_size");
     $("#user_datum_screen_size").val("Undefined");
   }else{
-    $("#screenSize").text(window.session.device.screen.width + " x " + window.session.device.screen.height);
-    styleAsPassed("#screenSize");
+    $("#screen_size").text(window.session.device.screen.width + " x " + window.session.device.screen.height);
+    styleAsPassed("#screen_size");
     $("#user_datum_screen_size").val(window.session.device.screen.width + " x " + window.session.device.screen.height);
   }
 
   if(window.session.browser.os == undefined){
-    $("#os").text("Undefined");
-    styleAsFailed("#os");
+    $("#operating_system").text("Undefined");
+    styleAsFailed("#operating_system");
     $("#user_datum_operating_system").val("Undefined");
   }else{
-    $("#os").text(window.session.browser.os);
-    styleAsPassed("#os");
+    $("#operating_system").text(window.session.browser.os);
+    styleAsPassed("#operating_system");
     $("#user_datum_operating_system").val(window.session.browser.os);
   }
 
   if(window.session.browser.browser == undefined && window.session.browser.version == undefined){
-    $("#browser").text("Undefined");
-    styleAsFailed("#browser");
+    $("#web_browser").text("Undefined");
+    styleAsFailed("#web_browser");
     $("#user_datum_web_browser").val("Undefined");
   }else{
-    $("#browser").text(window.session.browser.browser + " Version: " + window.session.browser.version);
-    styleAsPassed("#browser");
+    $("#web_browser").text(window.session.browser.browser + " Version: " + window.session.browser.version);
+    styleAsPassed("#web_browser");
     $("#user_datum_web_browser").val(window.session.browser.browser + " Version: " + window.session.browser.version);
   }
 
   if(window.session.plugins.flash == true && window.session.plugins.flash != undefined){
-    $("#flashEnabled").text(window.session.plugins.flash);
-    styleAsPassed("#flashEnabled");
+    $("#flash_enabled").text(window.session.plugins.flash);
+    styleAsPassed("#flash_enabled");
     $("#user_datum_flash_enabled").val(window.session.plugins.flash);
   }else{
-    $("#flashEnabled").text("False");
-    styleAsFailed("#flashEnabled");
+    $("#flash_enabled").text("False");
+    styleAsFailed("#flash_enabled");
     $("#user_datum_flash_enabled").val("False");
   }
   if(Date() == undefined){
@@ -143,13 +143,13 @@ function testAll(){
 
   //Load data from control site https://control.continuity.net/favicon.ico
   $('#imagefavicon').on("error", function() {
-    $("#continuity").text("Not Loaded");
-    styleAsFailed("#continuity");
+    $("#continuity_site").text("Not Loaded");
+    styleAsFailed("#continuity_site");
     $("#user_datum_continuity_site").val("Not Loaded");
   });
   $('#imagefavicon').on("load", function(){
-    $("#continuity").text("Loaded");
-    styleAsPassed("#continuity");
+    $("#continuity_site").text("Loaded");
+    styleAsPassed("#continuity_site");
     $("#user_datum_continuity_site").val("Loaded");
   });
   $('#imagefavicon').attr('src', "https://control.continuity.net/browser-test.png");
@@ -200,15 +200,15 @@ function appendToOtherSites(loaded, text_to_display) {
   } else {
     third_party_site_failures += 1;
     if(third_party_site_failures == 1){
-      $("#3rdparty").text(
+      $("#other_sites").text(
         text_to_display
       );
       $("#user_datum_other_sites").val(
         text_to_display
       );
     } else {
-      $("#3rdparty").text(
-        $("#3rdparty").text() + ", " + text_to_display
+      $("#other_sites").text(
+        $("#other_sites").text() + ", " + text_to_display
       );
       $("#user_datum_other_sites").val(
         $("#user_datum_other_sites").val() + ", " + text_to_display
@@ -218,9 +218,9 @@ function appendToOtherSites(loaded, text_to_display) {
 
   // handle completion of loads and failures
   if(third_party_site_loads == 5){
-    $("#3rdparty").text('All loaded');
-    styleAsPassed("#3rdparty");
+    $("#other_sites").text('All loaded');
+    styleAsPassed("#other_sites");
   } else if (third_party_site_loads + third_party_site_failures == 6) {
-    styleAsFailed("#3rdparty");
+    styleAsFailed("#other_sites");
   }
 }

--- a/app/assets/javascripts/browser_test.js.erb
+++ b/app/assets/javascripts/browser_test.js.erb
@@ -20,14 +20,13 @@ function googlejsapi(){
   }
 }
 
-function replaceStyle(domID) {
+function styleAsPassed(domID) {
   $(domID).parents(".alert").removeClass("grey").removeClass('alert-error').addClass("alert-success");
 }
 
-function replaceStyleFalse(domID) {
+function styleAsFailed(domID) {
   $(domID).parents(".alert").removeClass("grey").addClass("alert-error");
 }
-
 
 function blacklisted() {
   var parser = new UAParser();
@@ -69,88 +68,88 @@ function testAll(){
 
   //loading data from client
   if(navigator.userAgent == undefined){
-    replaceStyleFalse("#userAgent");
+    styleAsFailed("#userAgent");
     $("#userAgent").text("Undefined");
     $("#user_datum_user_agent_string").val("Undefined");
   }else if(blacklisted()){
-    replaceStyleFalse("#userAgent");
+    styleAsFailed("#userAgent");
     $("#userAgent").text(navigator.userAgent);
     $("#userAgent").append("\n Your browser may be in a compatibility mode supporting an older version of IE.");
     $("#user_datum_user_agent_string").val(navigator.userAgent);
   }else{
     $("#userAgent").text(navigator.userAgent);
-    replaceStyle("#userAgent");
+    styleAsPassed("#userAgent");
     $("#user_datum_user_agent_string").val(navigator.userAgent);
   }
 
   if(window.session.device.viewport.width == undefined && window.session.device.viewport.height == undefined){
     $("#windowSize").text("Undefined");
-    replaceStyleFalse("#windowSize");
+    styleAsFailed("#windowSize");
     $("#user_datum_window_size").val("Undefined");
   }else{
     $("#windowSize").text( window.session.device.viewport.width + " x "+ window.session.device.viewport.height);
-    replaceStyle("#windowSize");
+    styleAsPassed("#windowSize");
     $("#user_datum_window_size").val(window.session.device.viewport.width + " x "+ window.session.device.viewport.height);
   }
 
   if(window.session.device.screen.width == undefined && window.session.device.screen.height == undefined){
     $("#screenSize").text("Undefined");
-    replaceStyleFalse("#screenSize");
+    styleAsFailed("#screenSize");
     $("#user_datum_screen_size").val("Undefined");
   }else{
     $("#screenSize").text(window.session.device.screen.width + " x " + window.session.device.screen.height);
-    replaceStyle("#screenSize");
+    styleAsPassed("#screenSize");
     $("#user_datum_screen_size").val(window.session.device.screen.width + " x " + window.session.device.screen.height);
   }
 
   if(window.session.browser.os == undefined){
     $("#os").text("Undefined");
-    replaceStyleFalse("#os");
+    styleAsFailed("#os");
     $("#user_datum_operating_system").val("Undefined");
   }else{
     $("#os").text(window.session.browser.os);
-    replaceStyle("#os");
+    styleAsPassed("#os");
     $("#user_datum_operating_system").val(window.session.browser.os);
   }
 
   if(window.session.browser.browser == undefined && window.session.browser.version == undefined){
     $("#browser").text("Undefined");
-    replaceStyleFalse("#browser");
+    styleAsFailed("#browser");
     $("#user_datum_web_browser").val("Undefined");
   }else{
     $("#browser").text(window.session.browser.browser + " Version: " + window.session.browser.version);
-    replaceStyle("#browser");
+    styleAsPassed("#browser");
     $("#user_datum_web_browser").val(window.session.browser.browser + " Version: " + window.session.browser.version);
   }
 
   if(window.session.plugins.flash == true && window.session.plugins.flash != undefined){
     $("#flashEnabled").text(window.session.plugins.flash);
-    replaceStyle("#flashEnabled");
+    styleAsPassed("#flashEnabled");
     $("#user_datum_flash_enabled").val(window.session.plugins.flash);
   }else{
     $("#flashEnabled").text("False");
-    replaceStyleFalse("#flashEnabled");
+    styleAsFailed("#flashEnabled");
     $("#user_datum_flash_enabled").val("False");
   }
   if(Date() == undefined){
     $("#date").text("Undefined");
-    replaceStyleFalse("#date");
+    styleAsFailed("#date");
     $("#user_datum_date").val("Undefined");
   }else{
     $("#date").text(Date());
-    replaceStyle("#date");
+    styleAsPassed("#date");
     $("#user_datum_date").val(Date());
   }
 
   //Load data from control site https://control.continuity.net/favicon.ico
   $('#imagefavicon').on("error", function() {
     $("#continuity").text("Not Loaded");
-    replaceStyleFalse("#continuity");
+    styleAsFailed("#continuity");
     $("#user_datum_continuity_site").val("Not Loaded");
   });
   $('#imagefavicon').on("load", function(){
     $("#continuity").text("Loaded");
-    replaceStyle("#continuity");
+    styleAsPassed("#continuity");
     $("#user_datum_continuity_site").val("Loaded");
   });
   $('#imagefavicon').attr('src', "https://control.continuity.net/browser-test.png");
@@ -220,8 +219,8 @@ function appendToOtherSites(loaded, text_to_display) {
   // handle completion of loads and failures
   if(third_party_site_loads == 5){
     $("#3rdparty").text('All loaded');
-    replaceStyle("#3rdparty");
+    styleAsPassed("#3rdparty");
   } else if (third_party_site_loads + third_party_site_failures == 6) {
-    replaceStyleFalse("#3rdparty");
+    styleAsFailed("#3rdparty");
   }
 }

--- a/app/assets/javascripts/browser_test.js.erb
+++ b/app/assets/javascripts/browser_test.js.erb
@@ -108,15 +108,14 @@ function testAll(){
     }
   });
 
-  if(window.session.device.screen.width == undefined && window.session.device.screen.height == undefined){
-    $("#screen_size").text("Undefined");
-    styleAsFailed("#screen_size");
-    $("#user_datum_screen_size").val("Undefined");
-  }else{
-    $("#screen_size").text(window.session.device.screen.width + " x " + window.session.device.screen.height);
-    styleAsPassed("#screen_size");
-    $("#user_datum_screen_size").val(window.session.device.screen.width + " x " + window.session.device.screen.height);
-  }
+  test('#screen_size', function(pass, fail) {
+    screen = window.session.device.screen;
+    if (screen.width == undefined && screen.height == undefined) {
+      fail("Undefined");
+    } else {
+      pass(screen.width + " x " +screen.height);
+    }
+  });
 
   if(window.session.browser.os == undefined){
     $("#operating_system").text("Undefined");

--- a/app/assets/javascripts/browser_test.js.erb
+++ b/app/assets/javascripts/browser_test.js.erb
@@ -117,15 +117,13 @@ function testAll(){
     }
   });
 
-  if(window.session.browser.os == undefined){
-    $("#operating_system").text("Undefined");
-    styleAsFailed("#operating_system");
-    $("#user_datum_operating_system").val("Undefined");
-  }else{
-    $("#operating_system").text(window.session.browser.os);
-    styleAsPassed("#operating_system");
-    $("#user_datum_operating_system").val(window.session.browser.os);
-  }
+  test('#operating_system', function(pass, fail) {
+    if (window.session.browser.os == undefined) {
+      fail("Undefined");
+    } else {
+      pass(window.session.browser.os);
+    }
+  });
 
   if(window.session.browser.browser == undefined && window.session.browser.version == undefined){
     $("#web_browser").text("Undefined");

--- a/app/assets/javascripts/browser_test.js.erb
+++ b/app/assets/javascripts/browser_test.js.erb
@@ -60,6 +60,28 @@ try {
 var third_party_site_loads;
 var third_party_site_failures;
 
+function test(id, testFunction) {
+  function userDatumId(test_id) {
+    return '#user_datum_' + test_id.substring(1);
+  }
+
+  var pass = function(message) {
+    styleAsPassed(id);
+    $(id).text(message);
+    var user_datum_id = userDatumId(id);
+    $(user_datum_id).val(message);
+  };
+
+  var fail = function(message) {
+    styleAsFailed(id);
+    $(id).text(message);
+    var user_datum_id = userDatumId(id);
+    $(user_datum_id).val(message);
+  }
+
+  testFunction(pass, fail);
+}
+
 function testAll(){
   // alert dismissal
   // $(".alert").alert();
@@ -67,20 +89,16 @@ function testAll(){
   third_party_site_failures = 0;
 
   //loading data from client
-  if(navigator.userAgent == undefined){
-    styleAsFailed("#user_agent_string");
-    $("#user_agent_string").text("Undefined");
-    $("#user_datum_user_agent_string").val("Undefined");
-  }else if(blacklisted()){
-    styleAsFailed("#user_agent_string");
-    $("#user_agent_string").text(navigator.userAgent);
-    $("#user_agent_string").append("\n Your browser may be in a compatibility mode supporting an older version of IE.");
-    $("#user_datum_user_agent_string").val(navigator.userAgent);
-  }else{
-    $("#user_agent_string").text(navigator.userAgent);
-    styleAsPassed("#user_agent_string");
-    $("#user_datum_user_agent_string").val(navigator.userAgent);
-  }
+  test('#user_agent_string', function(pass, fail) {
+    if (navigator.userAgent == undefined) {
+      fail('Undefined');
+    } else if (blacklisted()) {
+      fail(navigator.userAgent + "\n Your browser may be in a compatibility mode supporting an older version of IE.");
+    } else {
+      pass(navigator.userAgent);
+    }
+  });
+
 
   if(window.session.device.viewport.width == undefined && window.session.device.viewport.height == undefined){
     $("#window_size").text("Undefined");

--- a/app/assets/javascripts/browser_test.js.erb
+++ b/app/assets/javascripts/browser_test.js.erb
@@ -99,16 +99,14 @@ function testAll(){
     }
   });
 
-
-  if(window.session.device.viewport.width == undefined && window.session.device.viewport.height == undefined){
-    $("#window_size").text("Undefined");
-    styleAsFailed("#window_size");
-    $("#user_datum_window_size").val("Undefined");
-  }else{
-    $("#window_size").text( window.session.device.viewport.width + " x "+ window.session.device.viewport.height);
-    styleAsPassed("#window_size");
-    $("#user_datum_window_size").val(window.session.device.viewport.width + " x "+ window.session.device.viewport.height);
-  }
+  test('#window_size', function(pass, fail) {
+    var viewport = window.session.device.viewport;
+    if (viewport.width == undefined && viewport.height == undefined) {
+      fail('Undefined');
+    } else {
+      pass(viewport.width + " x " + viewport.height);
+    }
+  });
 
   if(window.session.device.screen.width == undefined && window.session.device.screen.height == undefined){
     $("#screen_size").text("Undefined");

--- a/app/assets/javascripts/browser_test.js.erb
+++ b/app/assets/javascripts/browser_test.js.erb
@@ -125,15 +125,14 @@ function testAll(){
     }
   });
 
-  if(window.session.browser.browser == undefined && window.session.browser.version == undefined){
-    $("#web_browser").text("Undefined");
-    styleAsFailed("#web_browser");
-    $("#user_datum_web_browser").val("Undefined");
-  }else{
-    $("#web_browser").text(window.session.browser.browser + " Version: " + window.session.browser.version);
-    styleAsPassed("#web_browser");
-    $("#user_datum_web_browser").val(window.session.browser.browser + " Version: " + window.session.browser.version);
-  }
+  test('#web_browser', function(pass, fail) {
+    var browser = window.session.browser;
+    if (browser.browser == undefined && browser.version == undefined) {
+      fail("Undefined");
+    } else {
+      pass(browser.browser + " Version: " + browser.version);
+    }
+  });
 
   if(window.session.plugins.flash == true && window.session.plugins.flash != undefined){
     $("#flash_enabled").text(window.session.plugins.flash);

--- a/app/views/browser_test/show.html.erb
+++ b/app/views/browser_test/show.html.erb
@@ -24,7 +24,7 @@
       <div class="alert continuity grey">
         <div>
           <h1>User Agent</h1>
-          <p id="userAgent">Javascript: Disabled</p>
+          <p id="user_agent_string">Javascript: Disabled</p>
         </div>
       </div>
     </div>
@@ -32,7 +32,7 @@
       <div class="alert continuity grey">
         <div>
           <h1>Window Size</h1>
-          <p id="windowSize">Javascript: Disabled</p>
+          <p id="window_size">Javascript: Disabled</p>
         </div>
       </div>
     </div>
@@ -43,7 +43,7 @@
       <div class="alert continuity grey">
         <div>
           <h1>Screen Size</h1>
-          <p id="screenSize">Javascript: Disabled</p>
+          <p id="screen_size">Javascript: Disabled</p>
         </div>
       </div>
     </div>
@@ -51,7 +51,7 @@
       <div class="alert continuity grey">
         <div>
           <h1>Operating System</h1>
-          <p id="os">Javascript: Disabled</p>
+          <p id="operating_system">Javascript: Disabled</p>
         </div>
       </div>
     </div>
@@ -62,7 +62,7 @@
       <div class="alert continuity grey">
         <div>
           <h1>Web Browser</h1>
-          <p id="browser">Javascript: Disabled</p>
+          <p id="web_browser">Javascript: Disabled</p>
         </div>
       </div>
     </div>
@@ -70,7 +70,7 @@
       <div class="alert continuity grey">
         <div>
           <h1>Flash Enabled</h1>
-          <p id="flashEnabled">Javascript: Disabled</p>
+          <p id="flash_enabled">Javascript: Disabled</p>
         </div>
       </div>
     </div>
@@ -100,7 +100,7 @@
       <div class="alert continuity grey">
         <div>
           <h1>3rd Party Sites</h1>
-          <p id="3rdparty">Javascript: Disabled</p>
+          <p id="other_sites">Javascript: Disabled</p>
         </div>
       </div>
     </div>
@@ -108,7 +108,7 @@
       <div class="alert continuity grey">
         <div>
           <h1>Control.Continuity.net Test</h1>
-          <p id="continuity">Javascript: Disabled</p>
+          <p id="continuity_site">Javascript: Disabled</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
There are a number of commits, but basically 4 changes:

First: Rename `replaceStyle` and `replaceStyleFalse` with `styleAsPassed` and `styleAsFailed`, to explain what they're for, and what they do.

Second: Make the DOM ids of the different tests match up with their corresponding UserDatum fields.

Let's pause here and explain. A browser test checks a number of things: screen size, browser version, OS, whether flash is enabled, etc. It also lets the user submit the data _directly_ to Desk.com. It does this by storing the outcome of each test it does - each green box - in a hidden form input; when the user enters their email address and submits the form, all those hidden inputs go along for the ride. The form stores all this in the database (really! It's called [UserDatum](https://github.com/ContinuityControl/BrowserTest/blob/master/app/models/user_datum.rb)) and queues a DJ job to email it (via a standard Rails mailer) to Desk.

The problem was that the view layer used javascript-style names like `flashEnabled`, and then it needed extra code to set the hidden form input named `user_datum_flash_enabled`. So I changed them to match - `flashEnabled` became `flash_enabled`. This lets us automate the part that a) makes the box green or red, and b) sets the corresponding UserDatum hidden form input.

Which brings us to the third change (series of changes, actually). Each check can now be boiled down to 4 parts: an HTML DOM id to display the results, a predicate (a function), a success message, and a failure message. The hidden form input ID can be calculated from the HTML DOM id (because, before, we made them all match). I added a `test` helper function that takes the DOM id, and a function, which gets passed a `pass` and a `fail` function. It does its check, and calls either `pass` or `fail`, which a) styles the right DOM id to show the user, and b) sets the hidden `user_datum` input. Each of these changes is in its own commit, because it would've been a diff shit-show.

The last part is kind of an after-thought. The last test checks that the user can access all these third-party things, and it's all wrapped up in one pass/fail block. It's awkward, but its awkwardness was aggravated by extracting 2 of the tests into their own functions. This made the repetition harder to see, so I inlined them. Things have to get worse before they get better, and this is the "worse" without the "better." But only by a little.
